### PR TITLE
Scripts cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-docker-run-tag-push
-======================
+docker-build-run-push
+=====================
 
 An easy way to excute the typical sequence of commands to build, run and push a node project
 to a private docker repo.
@@ -18,9 +18,9 @@ add the following to your package.json
 and add some scripts that look like this. You might adjust to your liking
 
        "scripts": {
-		    "docker-build": "rm -rf node_modules && npm i --production && ./node_modules/docker-build-run-push/docker-build",
-		    "docker-run": "./node_modules/docker-build-run-push/docker-run",
-		    "docker-push": "rm -rf node_modules && npm i --production && ./node_modules/docker-build-run-push/docker-push",
+		    "docker-build": "rm -rf node_modules && npm i --production && docker-build",
+		    "docker-run": "docker-run",
+		    "docker-push": "rm -rf node_modules && npm i --production && docker-push",
       },
 
 Now in your project, when you are ready bump your version number in package.json.

--- a/docker-build
+++ b/docker-build
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 VERSION=$(node -e "console.log(require('./package.json').version)")
 NAME=$(node -e "console.log(require('./package.json').name.split('/').pop())")

--- a/docker-push
+++ b/docker-push
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 VERSION=$(node -e "console.log(require('./package.json').version)")
 NAME=$(node -e "console.log(require('./package.json').name.split('/').pop())")

--- a/docker-run
+++ b/docker-run
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 VERSION=$(node -e "console.log(require('./package.json').version)")
 NAME=$(node -e "console.log(require('./package.json').name.split('/').pop())")

--- a/package.json
+++ b/package.json
@@ -14,5 +14,10 @@
   "bugs": {
     "url": "https://github.com/ryanramage/docker-build-run-push/issues"
   },
-  "homepage": "https://github.com/ryanramage/docker-build-run-push"
+  "homepage": "https://github.com/ryanramage/docker-build-run-push",
+  "bin": {
+    "docker-build": "./docker-build",
+    "docker-push": "./docker-push",
+    "docker-run": "./docker-run"
+  }
 }


### PR DESCRIPTION
- Correct cross-platform shebang
- Install scripts to the `node_modules/.bin` folder on package install
- Fix package title and scripts usage in the README
